### PR TITLE
Update http_proxy.go

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -378,7 +378,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				//	hg[n] = b ^ 0xCC
 				//}
 				// replace "Host" header
-				e_host := req.Host
+				// e_host := req.Host
 				if r_host, ok := p.replaceHostWithOriginal(req.Host); ok {
 					req.Host = r_host
 				}


### PR DESCRIPTION
commented `e_host` since not used because all occurencies are commented and giving error: `core/http_proxy.go:381:5: e_host declared and not used` compiling it.